### PR TITLE
Update server.rst

### DIFF
--- a/docs/server.rst
+++ b/docs/server.rst
@@ -77,7 +77,7 @@ following example shows that process id 6847 is using port 5000.
 
 macOS Monterey and later automatically starts a service that uses port
 5000. You can choose to disable this service instead of using a different port by
-searching for "AirPlay Receiver" in System Preferences and toggling it off.
+searching for "AirPlay Receiver" in System Settings and toggling it off.
 
 
 Deferred Errors on Reload


### PR DESCRIPTION
made changes to rename system preferences to system settings according to new mac os name change

Docs: Update macOS UI reference to “System Settings”

This PR updates the documentation in docs/server.rst to reflect the latest macOS UI terminology.
Specifically, it replaces the outdated term “System Preferences” with “System Settings”, aligning with macOS Ventura and later versions.

What Changed
	•	Line updated in instructions to disable AirPlay Receiver from:
	•	"System Preferences" → "System Settings"

Notes
	•	No issue was created for this change, as it is a minor documentation correction.
	•	This update does not affect any code or behavior.
	•	No test or changelog entry required per contribution guidelines for doc typo-level fixes.
